### PR TITLE
Added option to run in headless browser mode with --headless flag

### DIFF
--- a/bin/bin.js
+++ b/bin/bin.js
@@ -18,6 +18,8 @@ var argv = optimist
   .describe('port', 'Starts listening on that port and waits for you to open a browser')
   .alias('p', 'port')
 
+  .describe('headless', 'Runs the browser in headless mode')
+  .default('headless', false)
 
   .describe('help', 'Print help')
   .alias('h', 'help')

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function runner (opts) {
         if (err) console.error(err), process.exit(1);
 
         launch('http://localhost:' + port, {
-          headless: false,
+          headless: opts.headless || false,
           browser: opts.browser
         }, function (err, _ps) {
           if (err) console.error(err), process.exit(1);


### PR DESCRIPTION
Depends on xvfb to run a headless browser. Defaults to non-headless. 

`sudo apt-get install xvfb`
